### PR TITLE
Stricter sniff tests, new standards.cfg configuration option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",
+    "slevomat/coding-standard": "~4.0",
     "squizlabs/php_codesniffer": "^3.0"
   },
   "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f171202e0a64eb301b11bdf05fd1c23c",
+    "content-hash": "b5e190c4fca4926c657fbc7133a9c72e",
     "packages": [],
     "packages-dev": [
         {
@@ -362,23 +362,23 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.5",
+            "version": "1.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
@@ -421,20 +421,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-19T10:16:54+00:00"
+            "time": "2018-04-18T13:57:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.3",
+            "version": "6.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "774a82c0c5da4c1c7701790c262035d235ab7856"
+                "reference": "52187754b0eed0b8159f62a6fa30073327e8c2ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/774a82c0c5da4c1c7701790c262035d235ab7856",
-                "reference": "774a82c0c5da4c1c7701790c262035d235ab7856",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/52187754b0eed0b8159f62a6fa30073327e8c2ca",
+                "reference": "52187754b0eed0b8159f62a6fa30073327e8c2ca",
                 "shasum": ""
             },
             "require": {
@@ -484,7 +484,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:39:20+00:00"
+            "time": "2018-04-29T14:59:09+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -674,16 +674,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.1.2",
+            "version": "7.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6a17c170fb92845896e1b3b00fcb462cd4b3c017"
+                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6a17c170fb92845896e1b3b00fcb462cd4b3c017",
-                "reference": "6a17c170fb92845896e1b3b00fcb462cd4b3c017",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ca64dba53b88aba6af32aebc6b388068db95c435",
+                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435",
                 "shasum": ""
             },
             "require": {
@@ -701,8 +701,8 @@
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit-mock-objects": "^6.1",
-                "sebastian/comparator": "^2.1",
+                "phpunit/phpunit-mock-objects": "^6.1.1",
+                "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
@@ -750,7 +750,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-10T11:40:22+00:00"
+            "time": "2018-04-29T15:09:19+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -855,30 +855,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
+                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -915,7 +915,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2018-04-18T13:33:00+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1370,6 +1370,46 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "4.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "1e609159241fa90d5a429f185b2ea9b881340a7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/1e609159241fa90d5a429f185b2ea9b881340a7c",
+                "reference": "1e609159241fa90d5a429f185b2ea9b881340a7c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "squizlabs/php_codesniffer": "^3.2.3"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "phing/phing": "2.16",
+                "phpstan/phpstan": "0.9.2",
+                "phpstan/phpstan-phpunit": "0.9.4",
+                "phpstan/phpstan-strict-rules": "0.9",
+                "phpunit/php-code-coverage": "6.0.1",
+                "phpunit/phpunit": "7.0.2"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "time": "2018-03-08T08:14:33+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/es
+++ b/es
@@ -16,6 +16,8 @@ PHPCPD_MIN_TOKENS=${PHPCPD_MIN_TOKENS:=70}
 PHPCS_ENABLED=${PHPCS_ENABLED:=true}
 # The standards to compare code against, will be ignored if phpcs.xml exists
 PHPCS_STANDARDS=${PHPCS_STANDARDS:=vendor/eoneopay/standards/php-code-sniffer/EoneoPay}
+# Whether to show the code sniffs name on report output
+PHPCS_SHOW_SNIFF_NAME=${PHPCS_SHOW_SNIFF_NAME:=false}
 
 ########## PHP MESS DETECTOR CONFIGURATION ##########
 # Whether or not to run php mess destector, will run if phpmd binary is found
@@ -114,11 +116,12 @@ if ${PHPCS_ENABLED}; then
     resolve_executable phpcs
 
     if [ ${?} -eq 0 ]; then
+        show_sniff_arg=$([ "$PHPCS_SHOW_SNIFF_NAME" = true ] && echo '-s')
         echo "Running php code sniffer..."
         if [ -f phpcs.xml ]; then
-            results ${executable} --colors ${checks}
+            results ${executable} --colors ${checks} ${show_sniff_arg}
         else
-            results ${executable} --standard=${PHPCS_STANDARDS} --colors --report=full ${checks}
+            results ${executable} --standard=${PHPCS_STANDARDS} --colors --report=full ${checks} ${show_sniff_arg}
         fi
     fi
 fi

--- a/php-code-sniffer/EoneoPay/Sniffs/ControlStructures/NoElseSniff.php
+++ b/php-code-sniffer/EoneoPay/Sniffs/ControlStructures/NoElseSniff.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PHP_CodeSniffer\Standards\EoneoPay\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class NoElseSniff implements Sniff
+{
+    /***
+     * {@inheritdoc}
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $phpcsFile->addError('Else statement must not be used', $stackPtr, 'NoElse');
+    }
+
+    /***
+     * {@inheritdoc}
+     */
+    public function register()
+    {
+        return [T_ELSE];
+    }
+}

--- a/php-code-sniffer/EoneoPay/Sniffs/ControlStructures/NoNotOperatorSniff.php
+++ b/php-code-sniffer/EoneoPay/Sniffs/ControlStructures/NoNotOperatorSniff.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PHP_CodeSniffer\Standards\EoneoPay\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class NoNotOperatorSniff implements Sniff
+{
+    /***
+     * {@inheritdoc}
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $phpcsFile->addError('Strict comparision operator should be used instead', $stackPtr, 'NoNotOperator');
+        if (!false) {
+            return;
+        }
+    }
+
+    /***
+     * {@inheritdoc}
+     */
+    public function register()
+    {
+        return [T_BOOLEAN_NOT, T_IS_NOT_EQUAL];
+    }
+}

--- a/php-code-sniffer/EoneoPay/Sniffs/ControlStructures/NoNotOperatorSniff.php
+++ b/php-code-sniffer/EoneoPay/Sniffs/ControlStructures/NoNotOperatorSniff.php
@@ -13,9 +13,6 @@ class NoNotOperatorSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $phpcsFile->addError('Strict comparision operator should be used instead', $stackPtr, 'NoNotOperator');
-        if (!false) {
-            return;
-        }
     }
 
     /***

--- a/php-code-sniffer/EoneoPay/ruleset.xml
+++ b/php-code-sniffer/EoneoPay/ruleset.xml
@@ -9,4 +9,29 @@
     <!-- Import PSR1/2 as base -->
     <rule ref="PSR1"/>
     <rule ref="PSR2"/>
+
+    <config name="installed_paths" value="../../slevomat/coding-standard"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing">
+        <property name="linesCountBeforeFirstUse" value="1"/>
+        <property name="linesCountBetweenUseTypes" value="0"/>
+        <property name="linesCountAfterLastUse" value="0"/>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+        <properties>
+            <property name="enableEachParameterAndReturnInspection" value="0"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
Added new configuration option for showing PHP Code Sniffer sniff names on report output
`PHPCS_SHOW_SNIFF_NAME`

Updated composer dependencies

New sniffs added:
- else statement disallowed (elseif still legal)
- ‘Not’ operator (!) and not equal (!=) disallowed (strict operators to be used)
- Force class constant visibility to be specified
- ‘use declaration formatting enforced (1 line before first, 1 line after last)
- ‘use …’ must be alphabetical
- Group ‘use’ statements disallowed
- Multiple use imports on one line is disallowed
- use import references must not start with prefixed backwards slash 
- Global constants usage must be fully qualified
- Global functions usage must be fully qualified
- DocBlock type hints enforce short names (eg. Int instead of integer)
- Argument type hinting nullability enforced (eg. int $n = null is not legal, ?int $n = null is legal)
- Return type hinting & formatting enforced
- Empty comments disallowed
- Inline DocBlock formatting checked 
- Annotations class references must be fully qualified